### PR TITLE
Choose glTexImage2D gltype by image Channels(nrChennels)

### DIFF
--- a/disc0ver-Engine/disc0ver-Engine/Render/texture.cpp
+++ b/disc0ver-Engine/disc0ver-Engine/Render/texture.cpp
@@ -30,7 +30,7 @@ disc0ver::Texture::Texture(const GLchar* texturePath)
 	unsigned char* data = stbi_load(texturePath, &width, &height, &nrChannels, 0);
 	if (data) {
 		// TODO: 不同类型的图片选取什么读取方式优化
-		if (std::string(texturePath).find(".png") != -1) {
+		if (nrChannels == 4) {
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 			glGenerateMipmap(GL_TEXTURE_2D);
 		}


### PR DESCRIPTION
# 有关glTexImage2D 加载时候 RGBA通道数量的判断

之前试了一下，有些png图片也只有**三个颜色通道**，所以直接用stb读取的的nrChennels来判断读取的方式会不会更好一点？
